### PR TITLE
Change default text to "Log out" with a space

### DIFF
--- a/resources/views/components/buttons/logout.blade.php
+++ b/resources/views/components/buttons/logout.blade.php
@@ -2,6 +2,6 @@
     @csrf
 
     <button type="submit" {{ $attributes }}>
-        {{ $slot->isEmpty() ? __('Logout') : $slot }}
+        {{ $slot->isEmpty() ? __('Log out') : $slot }}
     </button>
 </form>


### PR DESCRIPTION
Clicking a button is an action, and so the text for it should be a verb phrase that describes the action.

As [Matt Stauffer](https://twitter.com/stauffermatt/status/1036953677704163330) recently brought up, this means a button makes more sense to say "Log out" with a space character, instead of the noun "Logout".

Figure this should be the default that such a kit follows.