### PR TITLE
Google Maps Component

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -36,6 +36,7 @@ return [
         'html' => Components\Layouts\Html::class,
         'social-meta' => Components\Layouts\SocialMeta::class,
         'mapbox' => Components\Maps\Mapbox::class,
+        'google-map' => Components\Maps\GoogleMap::class,
         'markdown' => Components\Markdown\Markdown::class,
         'toc' => Components\Markdown\ToC::class,
         'dropdown' => Components\Navigation\Dropdown::class,
@@ -119,6 +120,8 @@ return [
             'https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.css',
             'https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.js',
         ],
+
+        'google-maps' => 'https://maps.googleapis.com/maps/api/js?key=' . env('GOOGLEMAPS')
 
     ],
 

--- a/resources/views/components/maps/google-map.blade.php
+++ b/resources/views/components/maps/google-map.blade.php
@@ -1,0 +1,16 @@
+<div
+    style="height:-webkit-fill-available"
+    x-data="{
+        initGoogleMap: function () {
+            var el = document.getElementById('{{ $id }}')
+            var map = new google.maps.Map(el, {{ json_encode($options()) }});
+
+            @foreach($googleMarkers() as $marker)
+                var marker = new google.maps.Marker({position: {{ json_encode($marker) }}, map: map});
+            @endforeach
+        }
+    }"
+    x-init="() => initGoogleMap()"
+    id="{{ $id }}"
+    {{ $attributes }}
+></div>

--- a/src/BladeUIKitServiceProvider.php
+++ b/src/BladeUIKitServiceProvider.php
@@ -87,7 +87,7 @@ final class BladeUIKitServiceProvider extends ServiceProvider
             });
 
             collect($files)->filter(function (string $file) {
-                return Str::endsWith($file, '.js');
+                return Str::endsWith($file, '.js') || Str::contains($file, 'googleapis.com/maps');
             })->each(function (string $script) {
                 BladeUIKit::addScript($script);
             });

--- a/src/Components/Maps/GoogleMap.php
+++ b/src/Components/Maps/GoogleMap.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUIKit\Components\Maps;
+
+use BladeUIKit\Components\BladeComponent;
+use Illuminate\Contracts\View\View;
+
+class GoogleMap extends BladeComponent
+{
+    /** @var string */
+    public $id;
+
+    /** @var array */
+    public $center;
+
+    /** @var int */
+    public $zoom;
+
+    /** @var array */
+    public $options;
+
+    /** @var array */
+    public $markers;
+
+    protected static $assets = ['alpine', 'google-maps'];
+
+    public function __construct(
+        string $id = 'map',
+        array $center = [33.7633864,-84.3973038],
+        int $zoom = 15,
+        array $options = [],
+        array $markers = []
+    ) {
+        $this->id = $id;
+        $this->center = $center;
+        $this->zoom = $zoom;
+        $this->options = $options;
+        $this->markers = $markers;
+    }
+
+    public function googleMarkers()
+    {
+        return collect($this->markers)->map(function ($marker) {
+            return [
+                'lat' => $marker[0],
+                'lng' => $marker[1]
+            ];
+        });
+    }
+
+    public function render(): View
+    {
+        return view('blade-ui-kit::components.maps.google-map');
+    }
+
+    public function options(): array
+    {
+        return array_merge([
+            'center' => [
+                'lat' => $this->center[0],
+                'lng' => $this->center[1]
+            ],
+            'zoom' => $this->zoom
+        ], $this->options);
+    }
+}

--- a/tests/Components/Maps/GoogleMapTest.php
+++ b/tests/Components/Maps/GoogleMapTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Components\Maps;
+
+use Tests\Components\ComponentTestCase;
+
+class GoogleMapTest extends ComponentTestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+    }
+
+    /** @test */
+    public function the_component_can_be_rendered()
+    {
+        $expected = <<<HTML
+<div style="height:-webkit-fill-available" x-data="{ initGoogleMap: function () { var el = document.getElementById('map') var map = new google.maps.Map(el, {&quot;center&quot;:{&quot;lat&quot;:33.7633864,&quot;lng&quot;:-84.3973038},&quot;zoom&quot;:15}); } }" x-init="() =>
+    initGoogleMap()" id="map"></div>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-google-map/>');
+    }
+
+    /** @test */
+    public function options_can_be_passed()
+    {
+        $expected = <<<HTML
+<div style="height:-webkit-fill-available" x-data="{ initGoogleMap: function () { var el = document.getElementById('custom-map') var map = new google.maps.Map(el, {&quot;center&quot;:{&quot;lat&quot;:33.7633864,&quot;lng&quot;:-84.3973038},&quot;zoom&quot;:0}); } }" x-init="() =>
+    initGoogleMap()" id="custom-map"></div>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-google-map id="custom-map" :options="[\'zoom\' => 0]"/>');
+    }
+
+    /** @test */
+    public function markers_can_be_placed()
+    {
+        $expected = <<<HTML
+<div style="height:-webkit-fill-available" x-data="{ initGoogleMap: function () { var el = document.getElementById('map') var map = new google.maps.Map(el, {&quot;center&quot;:{&quot;lat&quot;:33.7633864,&quot;lng&quot;:-84.3973038},&quot;zoom&quot;:15}); var marker = new google.maps.Marker({position: {&quot;lat&quot;:13.41053,&quot;lng&quot;:52.52437}, map: map}); } }" x-init="() =>
+    initGoogleMap()" id="map"></div>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-google-map :markers="[[13.4105300, 52.5243700]]"/>');
+    }
+}


### PR DESCRIPTION
Love this package.

As suggested in #7 

Pretty similar to the mapbox implementation, except for a few things imposed by google maps API constraints:
- Requires an API key in your .env file as 'GOOGLEMAPS'
- Google maps API asset is not a file ending in '.js' - see dirty solution in BladeUIKitServiceProvider.php
- Google requires 'center' and 'zoom' to be defined to initialise a map, I have provided defaults, but you may prefer to remove these and make them mandatory props on the component
- Google maps require that the containing div has a height. I have used ```style="height:-webkit-fill-available"``` which means that the component's parent div needs a height. I can't think of a better way to resolve this (yet)

If you like this, I am happy to do a separate PR to the docs, and to continue working to add more features. 😀