### PR TITLE
adding and registering the File input component

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -42,6 +42,7 @@ return [
         'avatar' => Components\Support\Avatar::class,
         'cron' => Components\Support\Cron::class,
         'unsplash' => Components\Support\Unsplash::class,
+        'file' => Components\Forms\Inputs\File::class
     ],
 
     /*

--- a/resources/views/components/forms/inputs/file.blade.php
+++ b/resources/views/components/forms/inputs/file.blade.php
@@ -1,0 +1,22 @@
+<div>
+    <label for="file" style=" padding: .5rem; border-radius: 5px;" class="{{$buttonContainerClass}}">
+        {{$label}}
+    </label>
+
+    <span id="chosenFile" class="{{$fileContainerClass}}">
+    </span>
+
+    <input type="file" name="{{$name}}" id="file" style="display: none;">
+</div>
+
+<style>
+    label:hover {
+        color: #718096;
+    }
+</style>
+
+<script>
+    document.getElementById('file').onchange = function () {
+        document.getElementById('chosenFile').innerHTML = this.files[0].name;
+    };
+</script>

--- a/src/Components/Forms/Inputs/File.php
+++ b/src/Components/Forms/Inputs/File.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUIKit\Components\Forms\Inputs;
+
+use Illuminate\Contracts\View\View;
+
+class File extends Input
+{
+    public $label;
+    public $buttonContainerClass;
+    public $fileContainerClass;
+
+    public function __construct(string $value='', string $name = 'file', $label= 'Choose File', $buttonContainerClass = '', $fileContainerClass = '')
+    {
+        parent::__construct($name, 'file', 'file', $value);
+
+        $this->label = $label;
+        $this->fileContainerClass = $fileContainerClass;
+        $this->buttonContainerClass = $buttonContainerClass;
+    }
+
+    public function render(): View
+    {
+        return view('blade-ui-kit::components.forms.inputs.file');
+    }
+}

--- a/tests/Components/Forms/Inputs/FileTest.php
+++ b/tests/Components/Forms/Inputs/FileTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Components\Forms\Inputs;
+
+use Tests\Components\ComponentTestCase;
+
+class FileTest extends ComponentTestCase
+{
+    /** @test */
+    public function the_component_can_be_rendered()
+    {
+
+        $expected = <<<HTML
+<div>
+
+                         <label for="file">
+                            Choose File
+                         </label>
+
+                         <span id="chosenFile" class="">
+                         </span>
+
+                         <input type="file" name="file" id="file" style="display: none;">
+</div>
+                   
+                    <style>
+                        label:hover {
+                          color: #718096;
+                            }
+                    </style>
+
+                    <script>
+                     document.getElementById('file').onchange = function () {
+                          document.getElementById('chosenFile').innerHTML = this.files[0].name;
+                       };
+                    </script>
+HTML;
+
+
+        $this->assertComponentRenders(
+            $expected,
+            '<x-file/>'
+        );
+    }
+
+    /** @test */
+    public function specific_attributes_can_be_overwritten()
+    {
+        $expected = <<<HTML
+<div>
+                       <label for="file">
+                          Choose Resume
+                       </label>
+
+                        <span id="chosenFile" class="">
+                        </span>
+
+                         <input type="file" name="user_resume" id="file" style="display: none;">
+                    </div>
+                   
+                    <style>
+                        label:hover {
+                          color: #718096;
+                            }
+                    </style>
+
+                    <script>
+                     document.getElementById('file').onchange = function () {
+                          document.getElementById('chosenFile').innerHTML = this.files[0].name;
+                       };
+                    </script>
+HTML;
+
+
+        $this->assertComponentRenders(
+            $expected,
+            '<x-file name="user_resume" label="Choose Resume" />'
+        );
+    }
+}


### PR DESCRIPTION
Motive: the default file input in browsers is not really good looking and needs some overhaul, what if we have a file component that has already solved this issue for us and its ready to call?

well this component solves this issue of creating custom file input components, since the component itself is a custom component and the first of it's kind in the blade-ui-kit