### PR TITLE
adding and registering File input component

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -42,6 +42,7 @@ return [
         'avatar' => Components\Support\Avatar::class,
         'cron' => Components\Support\Cron::class,
         'unsplash' => Components\Support\Unsplash::class,
+        'file' => Components\Forms\Inputs\File::class
     ],
 
     /*

--- a/resources/views/components/forms/inputs/file.blade.php
+++ b/resources/views/components/forms/inputs/file.blade.php
@@ -1,0 +1,22 @@
+<div>
+    <label for="file" style=" padding: .5rem; border-radius: 5px;" class="{{$buttonContainerClass}}">
+        {{$label}}
+    </label>
+
+    <span id="chosenFile" class="{{$fileContainerClass}}">
+    </span>
+
+    <input type="file" name="{{$name}}" id="file" style="display: none;">
+</div>
+
+<style>
+    label:hover {
+        color: #718096;
+    }
+</style>
+
+<script>
+    document.getElementById('file').onchange = function () {
+        document.getElementById('chosenFile').innerHTML = this.files[0].name;
+    };
+</script>

--- a/src/Components/Forms/Inputs/File.php
+++ b/src/Components/Forms/Inputs/File.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUIKit\Components\Forms\Inputs;
+
+use Illuminate\Contracts\View\View;
+
+class File extends Input
+{
+    public $label;
+    public $buttonContainerClass;
+    public $fileContainerClass;
+
+    public function __construct(string $value='', string $name = 'file', $label= 'Choose File', $buttonContainerClass = '', $fileContainerClass = '')
+    {
+        parent::__construct($name, 'file', 'file', $value);
+
+        $this->label = $label;
+        $this->fileContainerClass = $fileContainerClass;
+        $this->buttonContainerClass = $buttonContainerClass;
+    }
+
+    public function render(): View
+    {
+        return view('blade-ui-kit::components.forms.inputs.file');
+    }
+}

--- a/tests/Components/Forms/Inputs/FileTest.php
+++ b/tests/Components/Forms/Inputs/FileTest.php
@@ -20,7 +20,7 @@ class FileTest extends ComponentTestCase
     <span id="chosenFile" class="">
     </span>
     
-    <input type="file" name="user_resume" id="file" style="display: none;">
+    <input type="file" name="file" id="file" style="display: none;">
 </div>
 <style>
     label:hover { color: #718096; }

--- a/tests/Components/Forms/Inputs/FileTest.php
+++ b/tests/Components/Forms/Inputs/FileTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Components\Forms\Inputs;
+
+use Tests\Components\ComponentTestCase;
+
+class FileTest extends ComponentTestCase
+{
+    /** @test */
+    public function the_component_can_be_rendered()
+    {
+
+        $expected = <<<HTML
+<div>
+<div>
+    <label for="file" style=" padding: .5rem; border-radius: 5px;" class="">
+    Choose File </label>
+    <span id="chosenFile" class="">
+    </span>
+    
+    <input type="file" name="user_resume" id="file" style="display: none;">
+</div>
+<style>
+    label:hover { color: #718096; }
+</style>
+<script>
+    document.getElementById('file').onchange = function () {
+        document.getElementById('chosenFile').innerHTML = this.files[0].name;
+    };
+</script>
+HTML;
+
+
+        $this->assertComponentRenders(
+            $expected,
+            '<x-file/>'
+        );
+    }
+
+    /** @test */
+    public function specific_attributes_can_be_overwritten()
+    {
+        $expected = <<<HTML
+<div>
+    <label for="file" style=" padding: .5rem; border-radius: 5px;" class="">
+    Choose Resume </label>
+    <span id="chosenFile" class="">
+    </span>
+    
+    <input type="file" name="user_resume" id="file" style="display: none;">
+</div>
+<style>
+    label:hover { color: #718096; }
+</style>
+<script>
+    document.getElementById('file').onchange = function () {
+        document.getElementById('chosenFile').innerHTML = this.files[0].name;
+    };
+</script>
+HTML;
+
+
+        $this->assertComponentRenders(
+            $expected,
+            '<x-file name="user_resume" label="Choose Resume" />'
+        );
+    }
+}


### PR DESCRIPTION
Motive: the default file input component provided by browsers are not pleasing to the eye, most of the time it needs to be customized to make it viable within a design, what if we had a component that already took care of the designs for use?

this File input component solves this issue of the default styling, since it is now styles better than the default file input , and its a custom component itself, making the first of it's kind in the package
