### PR TITLE
Add New Leaflet JS Map Component

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -36,6 +36,7 @@ return [
         'html' => Components\Layouts\Html::class,
         'social-meta' => Components\Layouts\SocialMeta::class,
         'mapbox' => Components\Maps\Mapbox::class,
+        'leaflet' => Components\Maps\Leaflet::class,
         'markdown' => Components\Markdown\Markdown::class,
         'toc' => Components\Markdown\ToC::class,
         'dropdown' => Components\Navigation\Dropdown::class,
@@ -118,6 +119,11 @@ return [
         'mapbox' => [
             'https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.css',
             'https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.js',
+        ],
+
+        'leaflet' => [
+            'https://unpkg.com/leaflet@1.6.0/dist/leaflet.css',
+            'https://unpkg.com/leaflet@1.6.0/dist/leaflet.js',
         ],
 
     ],

--- a/resources/views/components/maps/leaflet.blade.php
+++ b/resources/views/components/maps/leaflet.blade.php
@@ -1,0 +1,35 @@
+<div
+    x-data="
+{
+    initLeaflet: function () {
+        var map = L.map('{{ $id }}', {{ json_encode($options()) }} );
+
+        @switch($basemap)
+            @case('osm')
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+                @break
+            @case('hot')
+                L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png').addTo(map);
+                @break
+            @case('terrain')
+                L.tileLayer('//{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png').addTo(map);
+                @break
+            @case('watercolor')
+                L.tileLayer('//{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png').addTo(map);
+                @break
+            @case('toner-light')
+                L.tileLayer('//{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png').addTo(map);
+                @break
+            @default
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+        @endswitch
+
+        @foreach ($markers as $marker)
+            L.marker({{ json_encode(array_reverse($marker)) }}).addTo(map);
+        @endforeach
+    }
+}"
+    x-init="initLeaflet()"
+    id="{{ $id }}"
+    {{ $attributes }}
+></div>

--- a/src/Components/Maps/Leaflet.php
+++ b/src/Components/Maps/Leaflet.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUIKit\Components\Maps;
+
+use BladeUIKit\Components\BladeComponent;
+use Illuminate\Contracts\View\View;
+
+class Leaflet extends BladeComponent
+{
+    /** @var string */
+    public $id;
+
+    /** @var string */
+    public $basemap;
+
+    /** @var array */
+    public $options;
+
+    /** @var array */
+    public $markers;
+
+    /** @var array */
+    public $center;
+
+    /** @var int */
+    public $zoom;
+
+    /** @var bool */
+    public $zoomControl;
+
+    protected static $assets = ['alpine', 'leaflet'];
+
+    public function __construct(
+        string $id = 'map',
+        string $basemap = 'osm',
+        array $options = [],
+        array $markers = [],
+        array $center = [0,0],
+        int $zoom = 8,
+        bool $zoomControl = false
+    ) {
+        $this->id = $id;
+        $this->basemap = $basemap;
+        $this->options = $options;
+        $this->markers = $markers;
+        $this->center = $center;
+        $this->zoom = $zoom;
+        $this->zoomControl = $zoomControl;
+    }
+
+    public function render(): View
+    {
+        return view('blade-ui-kit::components.maps.leaflet');
+    }
+
+    public function options(): array
+    {
+        return array_merge([
+            'center' => array_reverse($this->center),
+            'zoom' => $this->zoom,
+            'zoomControl' => $this->zoomControl,
+        ], $this->options);
+    }
+}

--- a/tests/Components/Maps/LeafletTest.php
+++ b/tests/Components/Maps/LeafletTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Components\Maps;
+
+use Tests\Components\ComponentTestCase;
+
+class LeafletTest extends ComponentTestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+    }
+
+    /** @test */
+    public function the_component_can_be_rendered()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[0,0],&quot;zoom&quot;:8,&quot;zoomControl&quot;:false} ); L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet/>');
+    }
+
+    /** @test */
+    public function basemap_can_be_passed()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[0,0],&quot;zoom&quot;:8,&quot;zoomControl&quot;:false} ); L.tileLayer('//{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png').addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet basemap="watercolor" />');
+    }
+
+    /** @test */
+    public function center_can_be_passed()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[52.1234,13.1234],&quot;zoom&quot;:8,&quot;zoomControl&quot;:false} ); L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet :center="[13.1234, 52.1234]" />');
+    }
+
+    /** @test */
+    public function zoom_can_be_passed()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[0,0],&quot;zoom&quot;:10,&quot;zoomControl&quot;:false} ); L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet :zoom="10" />');
+    }
+
+    /** @test */
+    public function zoomControl_can_be_set()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[0,0],&quot;zoom&quot;:8,&quot;zoomControl&quot;:true} ); L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet :zoomControl="true" />');
+    }
+
+    /** @test */
+    public function markers_can_be_placed()
+    {
+        $expected = <<<HTML
+<div x-data="
+{ initLeaflet: function () { var map = L.map('map', {&quot;center&quot;:[0,0],&quot;zoom&quot;:8,&quot;zoomControl&quot;:false} ); L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map); L.marker([52.52437,13.41053]).addTo(map); L.marker([48.85341,2.3488]).addTo(map); }
+}" x-init="initLeaflet()" id="map"></div>
+HTML;
+        $this->assertComponentRenders($expected, '<x-leaflet :markers="[[13.4105300, 52.5243700], [2.3488000, 48.8534100]]" />');
+    }
+}


### PR DESCRIPTION
This is a new map component as an alternative to MapBox or Google Maps.
Both of the latter require an API key and are not open source; LeafletJS is; providing a free and API-less option.

Leaflet provides one of the most expansive ways to implement a map, with plugins, and varying options in terms of data it can display.

It replicates the MapBox component functionality equally - and adds a couple of additional options:
- Initial Zoom
- Initial Center Location [lat,lon]
- Show/Hide Zoom Control

The built in basemaps are:
- osm : OpenStreetMap
- hot: HOT (Humanitarian OSM Team)
- terrain: Terrain
- watercolor : Pretty!
- toner-light: A light simple mapping style

The default is OSM.

![Screenshot 2020-09-03 at 19 47 29](https://user-images.githubusercontent.com/800650/92154828-558db000-ee1e-11ea-97b0-441d872650f5.png)

This component does not break any other features or components and compliments the existing MapBox.

It is tested the same as the MapBox component as well as the additional functionality.

Will PR to the docs if this get approved. 😄 