### PR TITLE
Flatpickr (DateTime) Component Integration

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -27,6 +27,7 @@ return [
         'easy-mde' => Components\Editors\EasyMDE::class,
         'email' => Components\Forms\Inputs\Email::class,
         'error' => Components\Forms\Error::class,
+        'flatpickr' => Components\Forms\Inputs\Flatpickr::class,
         'form' => Components\Forms\Form::class,
         'form-button' => Components\Buttons\FormButton::class,
         'html' => Components\Layouts\Html::class,
@@ -93,6 +94,11 @@ return [
         'easy-mde' => [
             'https://unpkg.com/easymde/dist/easymde.min.css',
             'https://unpkg.com/easymde/dist/easymde.min.js',
+        ],
+
+        'flatpickr' => [
+            'https://cdn.jsdelivr.net/npm/flatpickr@4.6.6/dist/flatpickr.min.css',
+            'https://cdn.jsdelivr.net/npm/flatpickr@4.6.6/dist/flatpickr.min.js',
         ],
 
         'mapbox' => [

--- a/resources/views/components/forms/inputs/flatpickr.blade.php
+++ b/resources/views/components/forms/inputs/flatpickr.blade.php
@@ -1,6 +1,10 @@
 <input
-    x-data
-    x-init="new Flatpickr({ field: $el {{ $jsonOptions() }} })"
+    x-data="{
+        initFlatpickr: function () {
+            flatpickr('#{{ $id }}', {{ $jsonOptions() }});
+        }
+    }"
+    x-init="initFlatpickr()"
     name="{{ $name }}"
     type="text"
     id="{{ $id }}"

--- a/resources/views/components/forms/inputs/flatpickr.blade.php
+++ b/resources/views/components/forms/inputs/flatpickr.blade.php
@@ -1,0 +1,10 @@
+<input
+    x-data
+    x-init="new Flatpickr({ field: $el {{ $jsonOptions() }} })"
+    name="{{ $name }}"
+    type="text"
+    id="{{ $id }}"
+    placeholder="{{ $placeholder }}"
+    @if($value)value="{{ $value }}"@endif
+    {{ $attributes }}
+/>

--- a/src/Components/Forms/Inputs/Flatpickr.php
+++ b/src/Components/Forms/Inputs/Flatpickr.php
@@ -14,6 +14,9 @@ class Flatpickr extends Input
     /** @var string */
     public $placeholder;
 
+    /** @var string */
+    public $enableTime;
+
     /** @var array */
     public $options;
 
@@ -23,13 +26,15 @@ class Flatpickr extends Input
         string $name,
         string $id = null,
         ?string $value = '',
-        string $format = 'DD/MM/YYYY',
+        string $format = 'd/m/Y',
+        bool $enableTime = false,
         string $placeholder = null,
         array $options = []
     ) {
         parent::__construct($name, $id, 'text', $value);
 
         $this->format = $format;
+        $this->enableTime = $enableTime;
         $this->placeholder = $placeholder ?? $format;
         $this->options = $options;
     }
@@ -37,7 +42,8 @@ class Flatpickr extends Input
     public function options(): array
     {
         return array_merge([
-            'format' => $this->format,
+            'dateFormat' => $this->format,
+            'enableTime' => $this->enableTime,
         ], $this->options);
     }
 
@@ -47,7 +53,7 @@ class Flatpickr extends Input
             return '';
         }
 
-        return ', ...' . json_encode((object) $this->options());
+        return json_encode((object) $this->options());
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Flatpickr.php
+++ b/src/Components/Forms/Inputs/Flatpickr.php
@@ -26,16 +26,16 @@ class Flatpickr extends Input
         string $name,
         string $id = null,
         ?string $value = '',
-        string $format = 'd/m/Y',
+        string $format = 'd-m-Y',
         bool $enableTime = false,
         string $placeholder = null,
         array $options = []
     ) {
         parent::__construct($name, $id, 'text', $value);
 
-        $this->format = $format;
+        $enableTime ? $this->format = $format.' H:i' : $this->format = $format;
         $this->enableTime = $enableTime;
-        $this->placeholder = $placeholder ?? $format;
+        $this->placeholder = $placeholder ?? $this->format;
         $this->options = $options;
     }
 

--- a/src/Components/Forms/Inputs/Flatpickr.php
+++ b/src/Components/Forms/Inputs/Flatpickr.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUIKit\Components\Forms\Inputs;
+
+use Illuminate\Contracts\View\View;
+
+class Flatpickr extends Input
+{
+    /** @var string */
+    public $format;
+
+    /** @var string */
+    public $placeholder;
+
+    /** @var array */
+    public $options;
+
+    protected static $assets = ['alpine', 'moment', 'flatpickr'];
+
+    public function __construct(
+        string $name,
+        string $id = null,
+        ?string $value = '',
+        string $format = 'DD/MM/YYYY',
+        string $placeholder = null,
+        array $options = []
+    ) {
+        parent::__construct($name, $id, 'text', $value);
+
+        $this->format = $format;
+        $this->placeholder = $placeholder ?? $format;
+        $this->options = $options;
+    }
+
+    public function options(): array
+    {
+        return array_merge([
+            'format' => $this->format,
+        ], $this->options);
+    }
+
+    public function jsonOptions(): string
+    {
+        if (empty($this->options())) {
+            return '';
+        }
+
+        return ', ...' . json_encode((object) $this->options());
+    }
+
+    public function render(): View
+    {
+        return view('blade-ui-kit::components.forms.inputs.flatpickr');
+    }
+}

--- a/src/Components/Forms/Inputs/Flatpickr.php
+++ b/src/Components/Forms/Inputs/Flatpickr.php
@@ -33,7 +33,7 @@ class Flatpickr extends Input
     ) {
         parent::__construct($name, $id, 'text', $value);
 
-        $enableTime ? $this->format = $format.' H:i' : $this->format = $format;
+        $enableTime ? $this->format = $format . ' H:i' : $this->format = $format;
         $this->enableTime = $enableTime;
         $this->placeholder = $placeholder ?? $this->format;
         $this->options = $options;

--- a/tests/Components/Forms/Inputs/FlatpickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatpickrTest.php
@@ -24,7 +24,7 @@ HTML;
         $this->flashOld(['birthday' => '23/03/1989']);
 
         $expected = <<<HTML
-<input x-data x-init="new Flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" value="23/03/1989" />
+<input x-data x-init="new flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" value="23/03/1989" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');

--- a/tests/Components/Forms/Inputs/FlatpickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatpickrTest.php
@@ -6,17 +6,13 @@ namespace Tests\Components\Forms\Inputs;
 
 use Tests\Components\ComponentTestCase;
 
-class PikadayTest extends ComponentTestCase
+class FlatpickrTest extends ComponentTestCase
 {
     /** @test */
     public function the_component_can_be_rendered()
     {
         $expected = <<<HTML
-<input x-data="{
-    initFlatpickr: function () {
-        flatpickr('#\$el', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;});
-    }
-}" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" />
+<input x-data="{ initFlatpickr: function () { flatpickr('#birthday', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;,&quot;enableTime&quot;:false}); } }" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');
@@ -25,16 +21,22 @@ HTML;
     /** @test */
     public function flatpickr_can_have_old_values()
     {
-        $this->flashOld(['birthday' => '23/03/1989']);
+        $this->flashOld(['birthday' => '23-03-1989']);
 
         $expected = <<<HTML
-<input x-data="{
-    initFlatpickr: function () {
-        flatpickr('#\$el', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;});
-    }
-}" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" value="23-03-1989" />
+<input x-data="{ initFlatpickr: function () { flatpickr('#birthday', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;,&quot;enableTime&quot;:false}); } }" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" value="23-03-1989" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');
+    }
+
+    /** @test */
+    public function flatpickr_can_have_time()
+    {
+        $expected = <<<HTML
+<input x-data="{ initFlatpickr: function () { flatpickr('#birthday', {&quot;dateFormat&quot;:&quot;d-m-Y H:i&quot;,&quot;enableTime&quot;:true}); } }" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y H:i" />
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-flatpickr name="birthday" enableTime />');
     }
 }

--- a/tests/Components/Forms/Inputs/FlatpickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatpickrTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Components\Forms\Inputs;
+
+use Tests\Components\ComponentTestCase;
+
+class PikadayTest extends ComponentTestCase
+{
+    /** @test */
+    public function the_component_can_be_rendered()
+    {
+        $expected = <<<HTML
+<input x-data x-init="new Flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" />
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');
+    }
+
+    /** @test */
+    public function flatpickr_can_have_old_values()
+    {
+        $this->flashOld(['birthday' => '23/03/1989']);
+
+        $expected = <<<HTML
+<input x-data x-init="new Flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" value="23/03/1989" />
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');
+    }
+}

--- a/tests/Components/Forms/Inputs/FlatpickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatpickrTest.php
@@ -12,7 +12,11 @@ class PikadayTest extends ComponentTestCase
     public function the_component_can_be_rendered()
     {
         $expected = <<<HTML
-<input x-data x-init="new Flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" />
+<input x-data="{
+    initFlatpickr: function () {
+        flatpickr('#\$el', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;});
+    }
+}" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');
@@ -24,7 +28,11 @@ HTML;
         $this->flashOld(['birthday' => '23/03/1989']);
 
         $expected = <<<HTML
-<input x-data x-init="new flatpickr({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="birthday" type="text" id="birthday" placeholder="DD/MM/YYYY" value="23/03/1989" />
+<input x-data="{
+    initFlatpickr: function () {
+        flatpickr('#\$el', {&quot;dateFormat&quot;:&quot;d-m-Y&quot;});
+    }
+}" x-init="initFlatpickr()" name="birthday" type="text" id="birthday" placeholder="d-m-Y" value="23-03-1989" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-flatpickr name="birthday"/>');


### PR DESCRIPTION
<!--
As requested, Flatpickr Date/Time picker inspired by the Pikaday component code. Added an option for enabling time on the component as well.

Options API works the same as the Pikaday component does, works with strings, numbers, booleans but does not work with Javascript callbacks.

Tests included are same as Pikaday but i added an additional one for the 'enableTime' feature.

Flatpickr is a common date/time picker, the main advantage over Pikaday is a nicer UI and the time capabilities.

I can make a PR to the docs this weekend.
-->
