### PR TITLE
Use custom URL when width or height is set for Unsplash image

### DIFF
--- a/src/Components/Support/Unsplash.php
+++ b/src/Components/Support/Unsplash.php
@@ -71,7 +71,7 @@ class Unsplash extends BladeComponent
                 'username' => $this->username,
                 'w' => $this->width,
                 'h' => $this->height,
-            ]))->json()['urls']['raw'];
+            ]))->json()['urls'][($this->width || $this->height ? 'custom' : 'raw')];
         });
     }
 }


### PR DESCRIPTION
Fix for #74 

A small change to ensure that the correct URL is returned when the width or height of an Unsplash image is set.

Currently, only the 'raw' URL is used. This does not include the parameters for setting width and height.

```
        return Cache::remember('unsplash.' . $this->photo, $this->ttl, function () use ($accessKey) {
            return Http::get("https://api.unsplash.com/photos/{$this->photo}", array_filter([
                'client_id' => $accessKey,
                'query' => $this->query,
                'featured' => $this->featured,
                'username' => $this->username,
                'w' => $this->width,
                'h' => $this->height,
            ]))->json()['urls'][($this->width || $this->height ? 'custom' : 'raw')];
        });
```