### PR TITLE
Allow providing fallback label

### DIFF
--- a/src/Components/Forms/Label.php
+++ b/src/Components/Forms/Label.php
@@ -13,9 +13,13 @@ class Label extends BladeComponent
     /** @var string */
     public $for;
 
-    public function __construct(string $for)
+    /** @var string|null */
+    public $fallback;
+
+    public function __construct(string $for, string $fallback = null)
     {
         $this->for = $for;
+        $this->fallback = $fallback;
     }
 
     public function render(): View
@@ -25,6 +29,6 @@ class Label extends BladeComponent
 
     public function fallback(): string
     {
-        return Str::ucfirst(str_replace('_', ' ', $this->for));
+        return $this->fallback ?? Str::ucfirst(str_replace('_', ' ', $this->for));
     }
 }

--- a/tests/Components/Forms/LabelTest.php
+++ b/tests/Components/Forms/LabelTest.php
@@ -19,4 +19,16 @@ class LabelTest extends ComponentTestCase
 
         $this->assertComponentRenders($expected, '<x-label for="first_name"/>');
     }
+
+    /** @test */
+    public function the_component_can_accept_a_fallback_label()
+    {
+        $expected = <<<'HTML'
+            <label for="password_confirmation">
+                Confirm password
+            </label>
+            HTML;
+
+        $this->assertComponentRenders($expected, '<x-label for="password_confirmation" fallback="Confirm password"/>');
+    }
 }


### PR DESCRIPTION
At the moment there's no way to control the label name - it's always a formatted version of the input name. This allows you to optionally pass in the fallback value and have it take precedence. 

I ran into this specific use-case when trying to get a fresh Laravel Breeze installation to work alongside Blade UI Kit.