### PR TITLE
Update BladeUIKit.php

### DIFF
--- a/src/BladeUIKit.php
+++ b/src/BladeUIKit.php
@@ -31,7 +31,7 @@ final class BladeUIKit
         }
 
         return collect(static::$styles)->map(function (string $style) {
-            return '<link href="'.$style.'" rel="stylesheet" />';
+            return '<link href="'.$style.'" rel="stylesheet" type="text/css" />';
         })->implode(PHP_EOL);
     }
 


### PR DESCRIPTION
should fix the Google Chrome warning "Resource interpreted as Stylesheet but transferred with MIME type text/plain"

<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
