### PR TITLE
Add l18n support to the Cron component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "gajus/dindent": "^2.0",
         "guzzlehttp/guzzle": "^6.5",
         "league/commonmark": "^1.4",
-        "lorisleiva/cron-translator": "^0.1.1",
+        "lorisleiva/cron-translator": "^0.2.0",
         "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^9.0"
     },
@@ -49,7 +49,7 @@
     },
     "suggest": {
         "league/commonmark": "Required to use the markdown component (^1.4).",
-        "lorisleiva/cron-translator": "Required to use the cron component (^0.1.1)."
+        "lorisleiva/cron-translator": "Required to use the cron component (^0.2.0)."
     },
     "config": {
         "sort-packages": true

--- a/src/Components/Support/Cron.php
+++ b/src/Components/Support/Cron.php
@@ -13,12 +13,20 @@ class Cron extends BladeComponent
     /** @var string */
     public $schedule;
 
+    /** @var string */
+    public $locale = 'en';
+
+    /** @var bool */
+    public $use24hour = false;
+
     /** @var bool */
     public $human = false;
 
-    public function __construct(string $schedule, bool $human = false)
+    public function __construct(string $schedule, string $locale = 'en', bool $use24hour = false, bool $human = false)
     {
         $this->schedule = $schedule;
+        $this->locale = $locale;
+        $this->use24hour = $use24hour;
         $this->human = $human;
     }
 
@@ -29,6 +37,6 @@ class Cron extends BladeComponent
 
     public function translate(): string
     {
-        return CronTranslator::translate($this->schedule);
+        return CronTranslator::translate($this->schedule, $this->locale, $this->use24hour);
     }
 }

--- a/tests/Components/Support/CronTest.php
+++ b/tests/Components/Support/CronTest.php
@@ -40,4 +40,40 @@ class CronTest extends ComponentTestCase
 
         $this->assertComponentRenders($expected, '<x-cron schedule="@weekly" human/>');
     }
+
+    /** @test */
+    public function it_can_translate_a_cron_to_a_supported_locale()
+    {
+        $expected = <<<'HTML'
+            <span title="@weekly">
+                Chaque dimanche à 12:00am
+            </span>
+            HTML;
+
+        $this->assertComponentRenders($expected, '<x-cron schedule="@weekly" locale="fr" human/>');
+    }
+
+    /** @test */
+    public function it_defaults_to_english_with_an_unknown_locale()
+    {
+        $expected = <<<'HTML'
+            <span title="@weekly">
+                Every Sunday at 12:00am
+            </span>
+            HTML;
+
+        $this->assertComponentRenders($expected, '<x-cron schedule="@weekly" locale="typo" human/>');
+    }
+
+    /** @test */
+    public function it_can_display_time_in_24_hour_format()
+    {
+        $expected = <<<'HTML'
+            <span title="@weekly">
+                Every Sunday at 0:00
+            </span>
+            HTML;
+
+        $this->assertComponentRenders($expected, '<x-cron schedule="@weekly" use24hour="true" human/>');
+    }
 }


### PR DESCRIPTION
This PR adds support for internationalization to the Cron component:

- Translate a cron to the specified locale
- Default to English with an unsupported locale
- Option to display time in the 24-hour format


PS: I'll of course prepare the docs PR one I know this one is approved to be merged 🙂