### PR TITLE
Add ability to provide $slot to a `label` component

### DIFF
--- a/resources/views/components/forms/label.blade.php
+++ b/resources/views/components/forms/label.blade.php
@@ -1,3 +1,3 @@
 <label for="{{ $for }}" {{ $attributes }}>
-    {{ $fallback }}
+    {{ $slot->isEmpty() ? $fallback : $slot }}
 </label>

--- a/tests/Components/Forms/LabelTest.php
+++ b/tests/Components/Forms/LabelTest.php
@@ -19,4 +19,16 @@ class LabelTest extends ComponentTestCase
 
         $this->assertComponentRenders($expected, '<x-label for="first_name"/>');
     }
+
+    /** @test */
+    public function the_component_can_be_rendered_with_arbitrary_slot()
+    {
+        $expected = <<<'HTML'
+            <label for="first_name">
+                Foo Name
+            </label>
+            HTML;
+
+        $this->assertComponentRenders($expected, '<x-label for="first_name">Foo Name</x-label>');
+    }
 }


### PR DESCRIPTION
Label component lacks ability to overwrite the content between the tag; this PR add this ability.

In most cases the standard <x-label for="field_name"/> is sufficient to generate proper HTML. 

However, in some cases (like implementing Stripe Elements forms, that uses kebab-case, for instance) it may be beneficial to overwrite this behavior:

```php
 <x-label for="field-name">Foo Bar</x-label>
```
to produce
```html
<label for="field-name">Foo Bar</label>
```