### PR TITLE
chore: update Alpine to 3.x

### DIFF
--- a/config/blade-ui-kit.php
+++ b/config/blade-ui-kit.php
@@ -89,7 +89,7 @@ return [
 
     'assets' => [
 
-        'alpine' => 'https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.3.5/dist/alpine.min.js',
+        'alpine' => 'https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js',
 
         'easy-mde' => [
             'https://unpkg.com/easymde/dist/easymde.min.css',

--- a/resources/views/components/forms/inputs/color-picker.blade.php
+++ b/resources/views/components/forms/inputs/color-picker.blade.php
@@ -12,7 +12,7 @@
             });
         }
     }"
-    x-init="initPickr($el)"
+    x-init="initPickr($root)"
     {{ $attributes->merge(['title' => $value]) }}
 >
     <div id="{{ $id }}"></div>

--- a/resources/views/components/forms/inputs/pikaday.blade.php
+++ b/resources/views/components/forms/inputs/pikaday.blade.php
@@ -1,10 +1,10 @@
 <input
     x-data
-    x-init="new Pikaday({ field: $el {{ $jsonOptions() }} })"
+    x-init="new Pikaday({ field: $root {{ $jsonOptions() }} })"
     name="{{ $name }}"
     type="text"
     id="{{ $id }}"
     placeholder="{{ $placeholder }}"
-    @if($value)value="{{ $value }}"@endif
+    @if($value) value="{{ $value }}" @endif
     {{ $attributes }}
 />

--- a/resources/views/components/maps/mapbox.blade.php
+++ b/resources/views/components/maps/mapbox.blade.php
@@ -1,7 +1,7 @@
 <div
     x-data="
 {
-    initMapbox: function () {
+    init: function () {
         mapboxgl.accessToken = '{{ config('services.mapbox.public_token') }}';
         var map = new mapboxgl.Map({{ json_encode($options()) }});
 
@@ -12,7 +12,6 @@
         @endforeach
     }
 }"
-    x-init="initMapbox()"
     id="{{ $id }}"
     {{ $attributes }}
 ></div>

--- a/resources/views/components/navigation/dropdown.blade.php
+++ b/resources/views/components/navigation/dropdown.blade.php
@@ -1,4 +1,4 @@
-<div x-data="{ open: false }" @click.away="open = false" {{ $attributes }}>
+<div x-data="{ open: false }" @click.outside="open = false" {{ $attributes }}>
     <div @click="open = ! open">
         {{ $trigger }}
     </div>

--- a/tests/Components/Navigation/DropdownTest.php
+++ b/tests/Components/Navigation/DropdownTest.php
@@ -24,7 +24,7 @@ class DropdownTest extends ComponentTestCase
             HTML;
 
         $expected = <<<'HTML'
-            <div x-data="{ open: false }" @click.away="open = false" class="text-gray-500">
+            <div x-data="{ open: false }" @click.outside="open = false" class="text-gray-500">
                 <div @click="open = ! open">
                     <button>Dries</button>
                


### PR DESCRIPTION
This pull request bumps the version of Alpine from 2.x to 3.x.

One notable difference here is that the script enqueued by BUK will always be the latest release of Alpine. Enqueuing a specific version of Alpine is problematic since the only way to bump the version is by releasing a new version of BUK.

Always using the latest version will allow users/developers to lock the version themselves by publishing the config file.

**TODO**:
* [x] Bump Alpine version to 3.x
* [ ] Check any components that rely on Alpine.