### PR TITLE
Fixes Call to undefined method bootIfNotBooted() on livewire components.

### DIFF
--- a/src/Components/LivewireComponent.php
+++ b/src/Components/LivewireComponent.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace BladeUIKit\Components;
 
-use Livewire\Livewire;
+use Livewire\Component;
 
-abstract class LivewireComponent extends Livewire
+abstract class LivewireComponent extends Component
 {
     /** @var array */
     protected static $assets = [];


### PR DESCRIPTION
Fixes Call to undefined method `bootIfNotBooted()` 

Blade Livewire component of BladeUIKit is extending wrong livewire class.
It should be `Livewire\Component` instead of `Livewire\Livewire`. otherwise the livewire components won't get booted.


Error Output:

Call to undefined method `bootIfNotBooted()` .

Please refer to https://github.com/livewire/livewire/blob/master/src/Component.php class to check the bootIfNotBooted() method.