### PR TITLE
Update Unavatar URL to Prevent Redirects

### DIFF
--- a/src/Components/Support/Avatar.php
+++ b/src/Components/Support/Avatar.php
@@ -45,9 +45,9 @@ class Avatar extends BladeComponent
         ]));
 
         if ($this->provider) {
-            return sprintf('https://unavatar.now.sh/%s/%s?%s', $this->provider, $this->search, $query);
+            return sprintf('https://unavatar.io/%s/%s?%s', $this->provider, $this->search, $query);
         }
 
-        return sprintf('https://unavatar.now.sh/%s?%s', $this->search, $query);
+        return sprintf('https://unavatar.io/%s?%s', $this->search, $query);
     }
 }

--- a/tests/Components/Support/AvatarTest.php
+++ b/tests/Components/Support/AvatarTest.php
@@ -12,7 +12,7 @@ class AvatarTest extends ComponentTestCase
     public function the_component_can_be_rendered()
     {
         $this->assertComponentRenders(
-            '<img src="https://unavatar.now.sh/johndoe?" />',
+            '<img src="https://unavatar.io/johndoe?" />',
             '<x-avatar search="johndoe"/>',
         );
     }
@@ -30,7 +30,7 @@ class AvatarTest extends ComponentTestCase
     public function it_accepts_providers()
     {
         $this->assertComponentRenders(
-            '<img src="https://unavatar.now.sh/gravatar/john@example.com?" />',
+            '<img src="https://unavatar.io/gravatar/john@example.com?" />',
             '<x-avatar search="john@example.com" provider="gravatar"/>',
         );
     }
@@ -39,7 +39,7 @@ class AvatarTest extends ComponentTestCase
     public function it_accepts_fallbacks()
     {
         $this->assertComponentRenders(
-            '<img src="https://unavatar.now.sh/johndoe?fallback=https%3A%2F%2Fexample.com%2Fimage.png" />',
+            '<img src="https://unavatar.io/johndoe?fallback=https%3A%2F%2Fexample.com%2Fimage.png" />',
             '<x-avatar search="johndoe" fallback="https://example.com/image.png"/>',
         );
     }


### PR DESCRIPTION
Currently the url for unavatar is `unavatar.now.sh` which redirects on load to `unavatar.vercel.app` which then redirects to `unavatar.io`, so this PR is to update the urls to `unavatar.io` so prevent extra redirects