### PR TITLE
[0.x] Make `action` optional for `FormButton` and `Form` components

### DIFF
--- a/resources/views/components/buttons/form-button.blade.php
+++ b/resources/views/components/buttons/form-button.blade.php
@@ -1,4 +1,4 @@
-<form method="POST" action="{{ $action }}">
+<form method="POST" @isset($action) action="{{ $action }}" @endisset>
     @csrf
     @method($method)
 

--- a/resources/views/components/forms/form.blade.php
+++ b/resources/views/components/forms/form.blade.php
@@ -1,4 +1,4 @@
-<form method="{{ $method !== 'GET' ? 'POST' : 'GET' }}" action="{{ $action }}" {!! $hasFiles ? 'enctype="multipart/form-data"' : '' !!} {{ $attributes }}>
+<form method="{{ $method !== 'GET' ? 'POST' : 'GET' }}" @isset($action) action="{{ $action }}" @endisset {!! $hasFiles ? 'enctype="multipart/form-data"' : '' !!} {{ $attributes }}>
     @csrf
     @method($method)
 

--- a/src/Components/Buttons/FormButton.php
+++ b/src/Components/Buttons/FormButton.php
@@ -9,13 +9,13 @@ use Illuminate\Contracts\View\View;
 
 class FormButton extends BladeComponent
 {
-    /** @var string */
+    /** @var string|null */
     public $action;
 
     /** @var string */
     public $method;
 
-    public function __construct(string $action, string $method = 'POST')
+    public function __construct(string $action = null, string $method = 'POST')
     {
         $this->action = $action;
         $this->method = strtoupper($method);

--- a/src/Components/Forms/Form.php
+++ b/src/Components/Forms/Form.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\View\View;
 
 class Form extends BladeComponent
 {
-    /** @var string */
+    /** @var string|null */
     public $action;
 
     /** @var string */
@@ -18,7 +18,7 @@ class Form extends BladeComponent
     /** @var bool */
     public $hasFiles;
 
-    public function __construct(string $action, string $method = 'POST', bool $hasFiles = false)
+    public function __construct(string $action = null, string $method = 'POST', bool $hasFiles = false)
     {
         $this->action = $action;
         $this->method = strtoupper($method);

--- a/tests/Components/Buttons/FormButtonTest.php
+++ b/tests/Components/Buttons/FormButtonTest.php
@@ -54,4 +54,25 @@ class FormButtonTest extends ComponentTestCase
 
         $this->assertComponentRenders($expected, $template);
     }
+
+    /** @test */
+    public function the_action_prop_is_optional()
+    {
+        $template = <<<'HTML'
+            <x-form-button method="DELETE">
+                Logout
+            </x-form-button>
+            HTML;
+
+        $expected = <<<'HTML'
+            <form method="POST">
+                <input type="hidden" name="_token" value="">
+                <input type="hidden" name="_method" value="DELETE">
+                <button type="submit">
+                Logout </button>
+            </form>
+            HTML;
+
+        $this->assertComponentRenders($expected, $template);
+    }
 }

--- a/tests/Components/Forms/FormTest.php
+++ b/tests/Components/Forms/FormTest.php
@@ -70,4 +70,25 @@ class FormTest extends ComponentTestCase
 
         $this->assertComponentRenders($expected, $template);
     }
+
+    /** @test */
+    public function the_action_prop_is_optional()
+    {
+        $template = <<<'HTML'
+            <x-form method="POST">
+                Form fields...
+            </x-form>
+            HTML;
+
+        $expected = <<<'HTML'
+            <form method="POST">
+                <input type="hidden" name="_token" value="">
+                <input type="hidden" name="_method" value="POST">
+                Form fields...
+
+            </form>
+            HTML;
+
+        $this->assertComponentRenders($expected, $template);
+    }
 }


### PR DESCRIPTION
The `action` attribute is optional on the the `<form>` element so this is a sensible change.

Closes #69.
Replaces #70.