### PR TITLE
Fix tests for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text eol=lf
 
 /.github export-ignore
 /tests export-ignore

--- a/src/Components/Markdown/Markdown.php
+++ b/src/Components/Markdown/Markdown.php
@@ -81,7 +81,7 @@ class Markdown extends BladeComponent
             $markdown = str_replace($match, "<!--code-block-$index-->", $markdown);
         });
 
-        $markdown = collect(explode(PHP_EOL, $markdown))
+        $markdown = collect(preg_split('/\r\n|\r|\n/', $markdown))
             ->map(function (string $line) {
                 // For levels 2 to 6.
                 $anchors = [

--- a/src/Components/Markdown/ToC.php
+++ b/src/Components/Markdown/ToC.php
@@ -29,7 +29,7 @@ class ToC extends BladeComponent
         // Remove code blocks which might contain headers.
         $markdown = preg_replace('(```[a-z]*\n[\s\S]*?\n```)', '', $markdown);
 
-        return collect(explode(PHP_EOL, $markdown))
+        return collect(preg_split('/\r\n|\r|\n/', $markdown))
             ->reject(function (string $line) {
                 // Only search for level 2 and 3 headings.
                 return ! Str::startsWith($line, '## ') && ! Str::startsWith($line, '### ');

--- a/tests/InteractsWithViews.php
+++ b/tests/InteractsWithViews.php
@@ -37,7 +37,8 @@ trait InteractsWithViews
             ViewFacade::addLocation(sys_get_temp_dir());
         }
 
-        $tempFile = tempnam($tempDirectory, 'laravel-blade').'.blade.php';
+        $tempFile = str_replace('.tmp', '_tmp', tempnam($tempDirectory, 'laravel-blade'));
+        $tempFile = $tempFile.'.blade.php';
 
         file_put_contents($tempFile, $template);
 


### PR DESCRIPTION
Thanks for this project!

I ran into some issues trying to contribute:
* The `.` in `.tmp` temporary files on Windows causes an issue with the View Finder. It incorrectly replaces the `.` with a slash `/`.
* Line endings were not configured in the project causing tests to fail on Windowsif you follow [GitHub's instructions](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings). It changes all line-endings to `CRLF`.
* In the Markdown component `PHP_EOL` would fail on Windows.

I believe I've fixed these problems in 3 commits. Let me know if I can change something about them or if I approached this the wrong way