### PR TITLE
Initiate FlatPickr component on page load instead of mouse-enter

### DIFF
--- a/resources/views/components/forms/inputs/flat-pickr.blade.php
+++ b/resources/views/components/forms/inputs/flat-pickr.blade.php
@@ -7,7 +7,7 @@
             this.picker = flatpickr(this.$el, {{ $jsonOptions() }});
         }
     }"
-    x-on:mouseenter="initPicker()"
+    x-init="$nextTick(() => { initPicker() })"
     name="{{ $name }}"
     type="text"
     id="{{ $id }}"

--- a/tests/Components/Forms/Inputs/FlatPickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatPickrTest.php
@@ -12,7 +12,8 @@ class FlatPickrTest extends ComponentTestCase
     public function the_component_can_be_rendered()
     {
         $expected = <<<'HTML'
-            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() => { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" />
+            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() =>
+            { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" />
             HTML;
 
         $this->assertComponentRenders($expected, '<x-flat-pickr name="birthday"/>');
@@ -24,7 +25,8 @@ class FlatPickrTest extends ComponentTestCase
         $this->flashOld(['birthday' => '23/03/1989']);
 
         $expected = <<<'HTML'
-            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() => { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" value="23/03/1989" />
+            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() =>
+            { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" value="23/03/1989" />
             HTML;
 
         $this->assertComponentRenders($expected, '<x-flat-pickr name="birthday"/>');

--- a/tests/Components/Forms/Inputs/FlatPickrTest.php
+++ b/tests/Components/Forms/Inputs/FlatPickrTest.php
@@ -12,7 +12,7 @@ class FlatPickrTest extends ComponentTestCase
     public function the_component_can_be_rendered()
     {
         $expected = <<<'HTML'
-            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-on:mouseenter="initPicker()" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" />
+            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() => { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" />
             HTML;
 
         $this->assertComponentRenders($expected, '<x-flat-pickr name="birthday"/>');
@@ -24,7 +24,7 @@ class FlatPickrTest extends ComponentTestCase
         $this->flashOld(['birthday' => '23/03/1989']);
 
         $expected = <<<'HTML'
-            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-on:mouseenter="initPicker()" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" value="23/03/1989" />
+            <input x-data="{ picker: null, initPicker() { if (this.picker) return; this.picker = flatpickr(this.$el, {&quot;dateFormat&quot;:&quot;Y-m-d H:i&quot;,&quot;altInput&quot;:true,&quot;enableTime&quot;:true}); } }" x-init="$nextTick(() => { initPicker() })" name="birthday" type="text" id="birthday" placeholder="Y-m-d H:i" value="23/03/1989" />
             HTML;
 
         $this->assertComponentRenders($expected, '<x-flat-pickr name="birthday"/>');


### PR DESCRIPTION
Currently the flatpickr component only get loaded when a  mouse hovers the input. When using this with an empty value this doesn't have any issues. But when you're on the edit page of a traditional CRUD design you will first see an unformatted default HTML input and it 'jumps' to a different format when hovering. See the attached video for an example.


https://github.com/blade-ui-kit/blade-ui-kit/assets/4124579/beb53b78-1efb-4ecf-ac58-18b44c918c05



By replacing the mouse-enter with  `x-init` and `nextTick` we ensure that the flatpickr components [get loaded after Alpine has completely finished rendering ](https://alpinejs.dev/directives/init#next-tick).

This way when a value is set for the flatpickr it will be initiated correctly with this format.