### PR TITLE
Fix `ToC` split markdown

### DIFF
--- a/src/Components/Markdown/ToC.php
+++ b/src/Components/Markdown/ToC.php
@@ -29,7 +29,7 @@ class ToC extends BladeComponent
         // Remove code blocks which might contain headers.
         $markdown = preg_replace('(```[a-z]*\n[\s\S]*?\n```)', '', $markdown);
 
-        return collect(explode(PHP_EOL, $markdown))
+        return collect(preg_split('/\n|\r\n?/', $markdown))
             ->reject(function (string $line) {
                 // Only search for level 2 and 3 headings.
                 return ! Str::startsWith($line, '## ') && ! Str::startsWith($line, '### ');


### PR DESCRIPTION
Hello 👋🏻 

I had a case where my markdown End Of Line is `\n` so the `ToC` component was not able to split it properly because it's based on `PHP_EOL` which equal to `\r\n`.

In this PR I have added `\n` as option with `\r\n` so in both cases `ToC` would work as expected.
