### PR TITLE
Throw error on Unsplash API fail

### DIFF
--- a/src/Components/Support/Unsplash.php
+++ b/src/Components/Support/Unsplash.php
@@ -70,7 +70,9 @@ class Unsplash extends BladeComponent
                 'query' => $this->query,
                 'featured' => $this->featured,
                 'username' => $this->username,
-            ]))->json()['urls']['raw'];
+            ]))
+            ->throw()
+            ->json()['urls']['raw'];
         });
 
         if ($this->width || $this->height) {

--- a/tests/Components/Support/UnsplashTest.php
+++ b/tests/Components/Support/UnsplashTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\View\ViewException;
 
 beforeEach(function () {
     config()->set('services.unsplash.access_key', 'testing');
@@ -27,3 +29,13 @@ it('can set a specific width or height', function () {
 
     expect(blade('<x-unsplash photo="t9Td0zfDTwI" width="200"/>'))->toMatchSnapshot();
 });
+
+it('throws an error when the photo url in invalid', function () {
+    $url = 'https://images.unsplash.com/does-not-exist';
+
+    Http::fake([
+        'unsplash.com/*' => Http::response(['urls' => ['raw' => $url]], 404, ['Headers']),
+    ]);
+
+    blade('<x-unsplash photo="foo" width="200"/>');
+})->throws(ViewException::class)->only();


### PR DESCRIPTION
Fixes https://github.com/blade-ui-kit/blade-ui-kit/issues/127

I just added the `throw` method on the HTTP request and this is how the error looks like.

![SCR-20240329-plun-2](https://github.com/blade-ui-kit/blade-ui-kit/assets/10696975/f3c2310f-7b89-4eff-8c46-85248026d12c)


Is it enough?
