### PR TITLE
Remove unnecessary `only` method from test

### DIFF
--- a/tests/Components/Support/UnsplashTest.php
+++ b/tests/Components/Support/UnsplashTest.php
@@ -38,4 +38,4 @@ it('throws an error when the photo url in invalid', function () {
     ]);
 
     blade('<x-unsplash photo="foo" width="200"/>');
-})->throws(ViewException::class)->only();
+})->throws(ViewException::class);


### PR DESCRIPTION


@driesvints by mistake I pushed (in https://github.com/blade-ui-kit/blade-ui-kit/pull/155) a test with `only` method called, and made the test suite to run only one test.
