### PR TITLE
fix PHP 8.4 deprecation for implicit nullables

### DIFF
--- a/src/Components/Buttons/FormButton.php
+++ b/src/Components/Buttons/FormButton.php
@@ -15,7 +15,7 @@ class FormButton extends BladeComponent
     /** @var string */
     public $method;
 
-    public function __construct(string $action = null, string $method = 'POST')
+    public function __construct(?string $action = null, string $method = 'POST')
     {
         $this->action = $action;
         $this->method = strtoupper($method);

--- a/src/Components/Buttons/Logout.php
+++ b/src/Components/Buttons/Logout.php
@@ -12,7 +12,7 @@ class Logout extends BladeComponent
     /** @var string */
     public $action;
 
-    public function __construct(string $action = null)
+    public function __construct(?string $action = null)
     {
         $this->action = $action ?? route('logout');
     }

--- a/src/Components/Editors/EasyMDE.php
+++ b/src/Components/Editors/EasyMDE.php
@@ -20,7 +20,7 @@ class EasyMDE extends BladeComponent
 
     protected static $assets = ['alpine', 'easy-mde'];
 
-    public function __construct(string $name, string $id = null, array $options = [])
+    public function __construct(string $name, ?string $id = null, array $options = [])
     {
         $this->name = $name;
         $this->id = $id ?? $name;

--- a/src/Components/Editors/Trix.php
+++ b/src/Components/Editors/Trix.php
@@ -20,7 +20,7 @@ class Trix extends BladeComponent
 
     protected static $assets = ['trix'];
 
-    public function __construct(string $name, string $id = null, string $styling = 'trix-content')
+    public function __construct(string $name, ?string $id = null, string $styling = 'trix-content')
     {
         $this->name = $name;
         $this->id = $id ?? $name;

--- a/src/Components/Forms/Form.php
+++ b/src/Components/Forms/Form.php
@@ -18,7 +18,7 @@ class Form extends BladeComponent
     /** @var bool */
     public $hasFiles;
 
-    public function __construct(string $action = null, string $method = 'POST', bool $hasFiles = false)
+    public function __construct(?string $action = null, string $method = 'POST', bool $hasFiles = false)
     {
         $this->action = $action;
         $this->method = strtoupper($method);

--- a/src/Components/Forms/Inputs/Checkbox.php
+++ b/src/Components/Forms/Inputs/Checkbox.php
@@ -11,7 +11,7 @@ class Checkbox extends Input
     /** @var bool */
     public $checked;
 
-    public function __construct(string $name, string $id = null, bool $checked = false, ?string $value = '')
+    public function __construct(string $name, ?string $id = null, bool $checked = false, ?string $value = '')
     {
         parent::__construct($name, $id, 'checkbox', $value);
 

--- a/src/Components/Forms/Inputs/ColorPicker.php
+++ b/src/Components/Forms/Inputs/ColorPicker.php
@@ -14,7 +14,7 @@ class ColorPicker extends Input
 
     protected static $assets = ['alpine', 'pickr'];
 
-    public function __construct(string $name, string $id = null, ?string $value = '', array $options = [])
+    public function __construct(string $name, ?string $id = null, ?string $value = '', array $options = [])
     {
         parent::__construct($name, $id, 'hidden', $value);
 

--- a/src/Components/Forms/Inputs/Email.php
+++ b/src/Components/Forms/Inputs/Email.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\View\View;
 
 class Email extends Input
 {
-    public function __construct(string $name = 'email', string $id = null, ?string $value = '')
+    public function __construct(string $name = 'email', ?string $id = null, ?string $value = '')
     {
         parent::__construct($name, $id, 'email', $value);
     }

--- a/src/Components/Forms/Inputs/FlatPickr.php
+++ b/src/Components/Forms/Inputs/FlatPickr.php
@@ -21,10 +21,10 @@ class FlatPickr extends Input
 
     public function __construct(
         string $name,
-        string $id = null,
+        ?string $id = null,
         ?string $value = '',
         string $format = 'Y-m-d H:i',
-        string $placeholder = null,
+        ?string $placeholder = null,
         array $options = []
     ) {
         parent::__construct($name, $id, 'text', $value);

--- a/src/Components/Forms/Inputs/Input.php
+++ b/src/Components/Forms/Inputs/Input.php
@@ -21,7 +21,7 @@ class Input extends BladeComponent
     /** @var string */
     public $value;
 
-    public function __construct(string $name, string $id = null, string $type = 'text', ?string $value = '')
+    public function __construct(string $name, ?string $id = null, string $type = 'text', ?string $value = '')
     {
         $this->name = $name;
         $this->id = $id ?? $name;

--- a/src/Components/Forms/Inputs/Password.php
+++ b/src/Components/Forms/Inputs/Password.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\View\View;
 
 class Password extends Input
 {
-    public function __construct(string $name = 'password', string $id = null)
+    public function __construct(string $name = 'password', ?string $id = null)
     {
         parent::__construct($name, $id, 'password');
     }

--- a/src/Components/Forms/Inputs/Pikaday.php
+++ b/src/Components/Forms/Inputs/Pikaday.php
@@ -21,10 +21,10 @@ class Pikaday extends Input
 
     public function __construct(
         string $name,
-        string $id = null,
+        ?string $id = null,
         ?string $value = '',
         string $format = 'DD/MM/YYYY',
-        string $placeholder = null,
+        ?string $placeholder = null,
         array $options = []
     ) {
         parent::__construct($name, $id, 'text', $value);

--- a/src/Components/Forms/Inputs/Textarea.php
+++ b/src/Components/Forms/Inputs/Textarea.php
@@ -18,7 +18,7 @@ class Textarea extends BladeComponent
     /** @var int */
     public $rows;
 
-    public function __construct(string $name, string $id = null, $rows = 3)
+    public function __construct(string $name, ?string $id = null, $rows = 3)
     {
         $this->name = $name;
         $this->id = $id ?? $name;

--- a/src/Components/Support/Unsplash.php
+++ b/src/Components/Support/Unsplash.php
@@ -38,8 +38,8 @@ class Unsplash extends BladeComponent
         string $query = '',
         bool $featured = false,
         string $username = '',
-        int $width = null,
-        int $height = null,
+        ?int $width = null,
+        ?int $height = null,
         int $ttl = 3600
     ) {
         $this->photo = $photo;


### PR DESCRIPTION
PHP 8.4 has deprecated implicit nullables in favor of explicit nullables. More info here: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Currently you'll see things like this in the logs
```
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Inputs\Checkbox::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Inputs/Checkbox.php on line 14
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Inputs\Input::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Inputs/Input.php on line 24
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Inputs\Email::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Inputs/Email.php on line 11
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Form::__construct(): Implicitly marking parameter $action as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Form.php on line 21
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Buttons\FormButton::__construct(): Implicitly marking parameter $action as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Buttons/FormButton.php on line 18
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Buttons\Logout::__construct(): Implicitly marking parameter $action as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Buttons/Logout.php on line 15
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Inputs\Password::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Inputs/Password.php on line 11
[01-Dec-2024 05:15:43 UTC] PHP Deprecated:  BladeUIKit\Components\Forms\Inputs\Textarea::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/blade-ui-kit/blade-ui-kit/src/Components/Forms/Inputs/Textarea.php on line 21
```
